### PR TITLE
sanitise package ID for Android

### DIFF
--- a/example-app/app.json
+++ b/example-app/app.json
@@ -22,7 +22,7 @@
         "backgroundColor": "#ffffff"
       },
       "edgeToEdgeEnabled": true,
-      "package": "com.callstack.node-api-example-app"
+      "package": "com.callstack.node_api_example_app"
     },
     "web": {
       "favicon": "./assets/favicon.png"


### PR DESCRIPTION
The Android app's package ID needs to use underscores rather than hyphens, otherwise it doesn't build.

![Screenshot 2025-07-09 at 19 22 02](https://github.com/user-attachments/assets/4e183194-25c8-4988-81b4-8ff4c275a918)
