### PR TITLE
Update package-lock.json

### DIFF
--- a/example-app/package-lock.json
+++ b/example-app/package-lock.json
@@ -24,6 +24,7 @@
     "..": {
       "version": "0.1.0",
       "devDependencies": {
+        "@types/jest": "^30.0.0",
         "bindings": "^1.5.0",
         "cmake-js": "^7.3.1",
         "cmake-rn": "^0.2.0",


### PR DESCRIPTION
After I ran `cd example-app && npm install`, my package lock ended up with one extra stray line. Opening this PR just so that contributors don't end up with unstaged changes when trying out the example.